### PR TITLE
Midnight Update

### DIFF
--- a/BeQuiet.lua
+++ b/BeQuiet.lua
@@ -74,13 +74,11 @@ var_frame:SetScript("OnEvent", function(self, event, arg1)
 		end
 
 		-- Turn off BeQuiet for Midnight launch. The saved var should get created here so it should only happen once.
-		if NEW_EXPAC_LAUNCH == nil then			
+		buildVersion, buildNumber, buildDate, interfaceVersion, localizedVersion, buildInfo = GetBuildInfo()
+		if NEW_EXPAC_LAUNCH == nil and buildVersion == '12.0.0' then			
 			NEW_EXPAC_LAUNCH = true
-			buildVersion, buildNumber, buildDate, interfaceVersion, localizedVersion, buildInfo = GetBuildInfo()
-			if buildVersion == '12.0.0' then
 				msg_user("Welcome to Midnight. BeQuiet has been turned off just this one time for the release of the new expansion. Use /bq on if you wish to reenable it.")
 				ENABLED = 0
-			end
 		end
 	end
 end)

--- a/BeQuiet.lua
+++ b/BeQuiet.lua
@@ -2,63 +2,88 @@ local ADDON_NAME, BQ = ...
 
 version = "v" .. C_AddOns.GetAddOnMetadata(ADDON_NAME, "Version") or ""
 
-WL_DEFAULT = {
-	"Temple of Fal'adora",
-	"Falanaar Tunnels",
-	"Shattered Locus",
-	"Crestfall",
-	"Snowblossom Village",
-	"Havenswood",
-	"Jorundall",
-	"Molten Cay",
-	"Un'gol Ruins",
-	"The Rotting Mire",
-	"Whispering Reef",
-	"Verdant Wilds",
-	"The Dread Chain",
-	"Skittering Hollow",
-	"Torghast, Tower of the Damned",
-
-	-- New in v10.1.7.3
-	"Stormwind City",
-	"Orgrimmar",
-	"Valdrakken",
-}
-
-table.sort(WL_DEFAULT)
-
-BL_DEFAULT = {}
-
---Initialize config variables if they are not saved
-if ENABLED == nil then
-	ENABLED = 1
+BQ_RED = "|cffff3333"
+function msg_user(msg)
+	print(BQ_RED..ADDON_NAME.."|r: "..(msg or ""))
 end
 
-if VO_ENABLED == nil then
-	VO_ENABLED = 0
-end
+-- 12.0.0 Historically we never properly waited for the addon to load before handling variables so do it now
+local var_frame = CreateFrame("Frame")
+var_frame:RegisterEvent("ADDON_LOADED")
+var_frame:SetScript("OnEvent", function(self, event, arg1)
+    if event == "ADDON_LOADED" and arg1 == "BeQuiet" then
+		WL_DEFAULT = {
+			-- Withered army training
+			"Temple of Fal'adora",
+			"Falanaar Tunnels",
+			"Shattered Locus",
+			-- Island Expeditions
+			"Crestfall",
+			"Snowblossom Village",
+			"Havenswood",
+			"Jorundall",
+			"Molten Cay",
+			"Un'gol Ruins",
+			"The Rotting Mire",
+			"Whispering Reef",
+			"Verdant Wilds",
+			"The Dread Chain",
+			"Skittering Hollow",
+			-- Choreghast
+			"Torghast, Tower of the Damned",
+			-- Main cities for new content launches
+			"Stormwind City",
+			"Orgrimmar",
+			"Valdrakken",
+			"Dornogal"
+		}
 
-if BQ_SHOW_HEADS == nil then
-	BQ_SHOW_HEADS = true
-end
+		table.sort(WL_DEFAULT)
 
-if VERBOSE == nil then
-	VERBOSE = 1
-end
+		BL_DEFAULT = {}
 
-if BQ_SUPPRESS_INSTANCES == nil then
-	BQ_SUPPRESS_INSTANCES = false
-end
+		--Initialize config variables if they are not saved
+		if ENABLED == nil then
+			ENABLED = 1
+		end
 
---Default whitelist includes the withered army training zones from legion and island expeditions from BFA
-if WHITELIST == nil then
-	WHITELIST = WL_DEFAULT
-end
+		if VO_ENABLED == nil then
+			VO_ENABLED = 0
+		end
 
--- BLACKLIST defaults to empty. This preserves off behavior from before.
-if BLACKLIST == nil then
-	BLACKLIST = BL_DEFAULT
-end
+		if BQ_SHOW_HEADS == nil then
+			BQ_SHOW_HEADS = true
+		end
+
+		if VERBOSE == nil then
+			VERBOSE = 1
+		end
+
+		if BQ_SUPPRESS_INSTANCES == nil then
+			BQ_SUPPRESS_INSTANCES = false
+		end
+
+		--Default whitelist includes the withered army training zones from legion and island expeditions from BFA
+		if WHITELIST == nil then
+			WHITELIST = WL_DEFAULT
+		end
+
+		-- BLACKLIST defaults to empty. This preserves off behavior from before.
+		if BLACKLIST == nil then
+			BLACKLIST = BL_DEFAULT
+		end
+
+		-- Turn off BeQuiet for Midnight launch. The saved var should get created here so it should only happen once.
+		if NEW_EXPAC_LAUNCH == nil then			
+			NEW_EXPAC_LAUNCH = true
+			buildVersion, buildNumber, buildDate, interfaceVersion, localizedVersion, buildInfo = GetBuildInfo()
+			if buildVersion == '12.0.0' then
+				msg_user("Welcome to Midnight. BeQuiet has been turned off just this one time for the release of the new expansion. Use /bq on if you wish to reenable it.")
+				ENABLED = 0
+			end
+		end
+	end
+end)
 
 --Create the frame
 local f = CreateFrame("Frame")
@@ -210,11 +235,6 @@ function replace_array(src, target)
 		--msg_user("adding",i,v)
 		target[i] = v
 	end
-end
-
-BQ_RED = "|cffff3333"
-function msg_user(msg)
-	print(BQ_RED..ADDON_NAME.."|r: "..(msg or ""))
 end
 
 --Slash command function

--- a/BeQuiet.toc
+++ b/BeQuiet.toc
@@ -1,4 +1,4 @@
-## Interface: 120000
+## Interface: 110205, 110207, 120000
 ## Version: 12.0.0.1
 ## Title: BeQuiet
 ## Author: Xorag

--- a/BeQuiet.toc
+++ b/BeQuiet.toc
@@ -1,9 +1,9 @@
-## Interface: 110002
-## Version: 11.0.2.1
+## Interface: 120000
+## Version: 12.0.0.1
 ## Title: BeQuiet
 ## Author: Xorag
 ## Notes: Suppresses talking chat head frame and audio
-## SavedVariables: ENABLED, VERBOSE, WHITELIST, BLACKLIST, VO_ENABLED, BQ_SHOW_HEADS, BQ_SUPPRESS_INSTANCES
+## SavedVariables: ENABLED, VERBOSE, WHITELIST, BLACKLIST, VO_ENABLED, BQ_SHOW_HEADS, BQ_SUPPRESS_INSTANCES, NEW_EXPAC_LAUNCH
 ## AddonCompartmentFunc: BeQuiet_BlizCompartment_OnClick
 ## IconTexture: 135975
 

--- a/libs/Ace3/AceComm-3.0/AceComm-3.0.lua
+++ b/libs/Ace3/AceComm-3.0/AceComm-3.0.lua
@@ -9,7 +9,7 @@
 -- make into AceComm.
 -- @class file
 -- @name AceComm-3.0
--- @release $Id: AceComm-3.0.lua 1284 2022-09-25 09:15:30Z nevcairiel $
+-- @release $Id: AceComm-3.0.lua 1333 2024-05-05 16:24:39Z nevcairiel $
 
 --[[ AceComm-3.0
 
@@ -20,7 +20,7 @@ TODO: Time out old data rotting around from dead senders? Not a HUGE deal since 
 local CallbackHandler = LibStub("CallbackHandler-1.0")
 local CTL = assert(ChatThrottleLib, "AceComm-3.0 requires ChatThrottleLib")
 
-local MAJOR, MINOR = "AceComm-3.0", 12
+local MAJOR, MINOR = "AceComm-3.0", 14
 local AceComm,oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 
 if not AceComm then return end
@@ -93,12 +93,12 @@ function AceComm:SendCommMessage(prefix, text, distribution, target, prio, callb
 
 	local textlen = #text
 	local maxtextlen = 255  -- Yes, the max is 255 even if the dev post said 256. I tested. Char 256+ get silently truncated. /Mikk, 20110327
-	local queueName = prefix..distribution..(target or "")
+	local queueName = prefix
 
 	local ctlCallback = nil
 	if callbackFn then
-		ctlCallback = function(sent)
-			return callbackFn(callbackArg, sent, textlen)
+		ctlCallback = function(sent, sendResult)
+			return callbackFn(callbackArg, sent, textlen, sendResult)
 		end
 	end
 

--- a/libs/Ace3/AceComm-3.0/ChatThrottleLib.lua
+++ b/libs/Ace3/AceComm-3.0/ChatThrottleLib.lua
@@ -23,7 +23,7 @@
 -- LICENSE: ChatThrottleLib is released into the Public Domain
 --
 
-local CTL_VERSION = 24
+local CTL_VERSION = 31
 
 local _G = _G
 
@@ -74,9 +74,7 @@ local math_max = math.max
 local next = next
 local strlen = string.len
 local GetFramerate = GetFramerate
-local strlower = string.lower
 local unpack,type,pairs,wipe = unpack,type,pairs,table.wipe
-local UnitInRaid,UnitInParty = UnitInRaid,UnitInParty
 
 
 -----------------------------------------------------------------------
@@ -112,6 +110,23 @@ function Ring:Remove(obj)
 		if self.pos == obj then
 			self.pos = nil
 		end
+	end
+end
+
+-- Note that this is local because there's no upgrade logic for existing ring
+-- metatables, and this isn't present on rings created in versions older than
+-- v25.
+local function Ring_Link(self, other)  -- Move and append all contents of another ring to this ring
+	if not self.pos then
+		-- This ring is empty, so just transfer ownership.
+		self.pos = other.pos
+		other.pos = nil
+	elseif other.pos then
+		-- Our tail should point to their head, and their tail to our head.
+		self.pos.prev.next, other.pos.prev.next = other.pos, self.pos
+		-- Our head should point to their tail, and their head to our tail.
+		self.pos.prev, other.pos.prev = other.pos.prev, self.pos.prev
+		other.pos = nil
 	end
 end
 
@@ -179,6 +194,13 @@ function ChatThrottleLib:Init()
 		self.Prio["BULK"] = { ByName = {}, Ring = Ring:New(), avail = 0 }
 	end
 
+	if not self.BlockedQueuesDelay then
+		-- v25: Add blocked queues to rings to handle new client throttles.
+		for _, Prio in pairs(self.Prio) do
+			Prio.Blocked = Ring:New()
+		end
+	end
+
 	-- v4: total send counters per priority
 	for _, Prio in pairs(self.Prio) do
 		Prio.nTotalSent = Prio.nTotalSent or 0
@@ -201,6 +223,7 @@ function ChatThrottleLib:Init()
 	self.Frame:SetScript("OnEvent", self.OnEvent)	-- v11: Monitor P_E_W so we can throttle hard for a few seconds
 	self.Frame:RegisterEvent("PLAYER_ENTERING_WORLD")
 	self.OnUpdateDelay = 0
+	self.BlockedQueuesDelay = 0
 	self.LastAvailUpdate = GetTime()
 	self.HardThrottlingBeginTime = GetTime()	-- v11: Throttle hard for a few seconds after startup
 
@@ -209,20 +232,43 @@ function ChatThrottleLib:Init()
 		-- Use secure hooks as of v16. Old regular hook support yanked out in v21.
 		self.securelyHooked = true
 		--SendChatMessage
-		hooksecurefunc("SendChatMessage", function(...)
-			return ChatThrottleLib.Hook_SendChatMessage(...)
-		end)
-		--SendAddonMessage
-		if _G.C_ChatInfo then
-			hooksecurefunc(_G.C_ChatInfo, "SendAddonMessage", function(...)
-				return ChatThrottleLib.Hook_SendAddonMessage(...)
+		if _G.C_ChatInfo and _G.C_ChatInfo.SendChatMessage then
+			hooksecurefunc(_G.C_ChatInfo, "SendChatMessage", function(...)
+				return ChatThrottleLib.Hook_SendChatMessage(...)
 			end)
 		else
-			hooksecurefunc("SendAddonMessage", function(...)
-				return ChatThrottleLib.Hook_SendAddonMessage(...)
+			hooksecurefunc("SendChatMessage", function(...)
+				return ChatThrottleLib.Hook_SendChatMessage(...)
+			end)
+		end
+		--SendAddonMessage
+		hooksecurefunc(_G.C_ChatInfo, "SendAddonMessage", function(...)
+			return ChatThrottleLib.Hook_SendAddonMessage(...)
+		end)
+	end
+
+	-- v26: Hook SendAddonMessageLogged for traffic logging
+	if not self.securelyHookedLogged then
+		self.securelyHookedLogged = true
+		hooksecurefunc(_G.C_ChatInfo, "SendAddonMessageLogged", function(...)
+			return ChatThrottleLib.Hook_SendAddonMessageLogged(...)
+		end)
+	end
+
+	-- v29: Hook BNSendGameData for traffic logging
+	if not self.securelyHookedBNGameData then
+		self.securelyHookedBNGameData = true
+		if _G.C_BattleNet and _G.C_BattleNet.SendGameData then
+			hooksecurefunc(_G.C_BattleNet, "SendGameData", function(...)
+				return ChatThrottleLib.Hook_BNSendGameData(...)
+			end)
+		else
+			hooksecurefunc("BNSendGameData", function(...)
+				return ChatThrottleLib.Hook_BNSendGameData(...)
 			end)
 		end
 	end
+
 	self.nBypass = 0
 end
 
@@ -250,6 +296,12 @@ function ChatThrottleLib.Hook_SendAddonMessage(prefix, text, chattype, destinati
 	size = size + tostring(destination or ""):len() + self.MSG_OVERHEAD
 	self.avail = self.avail - size
 	self.nBypass = self.nBypass + size	-- just a statistic
+end
+function ChatThrottleLib.Hook_SendAddonMessageLogged(prefix, text, chattype, destination, ...)
+	ChatThrottleLib.Hook_SendAddonMessage(prefix, text, chattype, destination, ...)
+end
+function ChatThrottleLib.Hook_BNSendGameData(destination, prefix, text)
+	ChatThrottleLib.Hook_SendAddonMessage(prefix, text, "WHISPER", destination)
 end
 
 
@@ -292,38 +344,89 @@ end
 -- - ... made up of N "Pipe"s (1 for each destination/pipename)
 -- - and each pipe contains messages
 
+local SendAddonMessageResult = Enum.SendAddonMessageResult or {
+	Success = 0,
+	AddonMessageThrottle = 3,
+	NotInGroup = 5,
+	ChannelThrottle = 8,
+	GeneralError = 9,
+}
+
+local function MapToSendResult(ok, ...)
+	local result
+
+	if not ok then
+		-- The send function itself errored; don't look at anything else.
+		result = SendAddonMessageResult.GeneralError
+	else
+		-- Grab the last return value from the send function and remap
+		-- it from a boolean to an enum code. If there are no results,
+		-- assume success (true).
+
+		result = select(-1, true, ...)
+
+		if result == true then
+			result = SendAddonMessageResult.Success
+		elseif result == false then
+			result = SendAddonMessageResult.GeneralError
+		end
+	end
+
+	return result
+end
+
+local function IsThrottledSendResult(result)
+	return result == SendAddonMessageResult.AddonMessageThrottle
+end
+
+-- A copy of this function exists in FrameXML, but for clarity it's here too.
+local function CallErrorHandler(...)
+	return geterrorhandler()(...)
+end
+
+local function PerformSend(sendFunction, ...)
+	bMyTraffic = true
+	local sendResult = MapToSendResult(xpcall(sendFunction, CallErrorHandler, ...))
+	bMyTraffic = false
+	return sendResult
+end
+
 function ChatThrottleLib:Despool(Prio)
 	local ring = Prio.Ring
 	while ring.pos and Prio.avail > ring.pos[1].nSize do
-		local msg = table_remove(ring.pos, 1)
-		if not ring.pos[1] then  -- did we remove last msg in this pipe?
-			local pipe = Prio.Ring.pos
+		local pipe = ring.pos
+		local msg = pipe[1]
+		local sendResult = PerformSend(msg.f, unpack(msg, 1, msg.n))
+
+		if IsThrottledSendResult(sendResult) then
+			-- Message was throttled; move the pipe into the blocked ring.
 			Prio.Ring:Remove(pipe)
-			Prio.ByName[pipe.name] = nil
-			DelPipe(pipe)
+			Prio.Blocked:Add(pipe)
 		else
-			Prio.Ring.pos = Prio.Ring.pos.next
-		end
-		local didSend=false
-		local lowerDest = strlower(msg[3] or "")
-		if lowerDest == "raid" and not UnitInRaid("player") then
-			-- do nothing
-		elseif lowerDest == "party" and not UnitInParty("player") then
-			-- do nothing
-		else
-			Prio.avail = Prio.avail - msg.nSize
-			bMyTraffic = true
-			msg.f(unpack(msg, 1, msg.n))
-			bMyTraffic = false
-			Prio.nTotalSent = Prio.nTotalSent + msg.nSize
+			-- Dequeue message after submission.
+			table_remove(pipe, 1)
 			DelMsg(msg)
-			didSend = true
+
+			if not pipe[1] then  -- did we remove last msg in this pipe?
+				Prio.Ring:Remove(pipe)
+				Prio.ByName[pipe.name] = nil
+				DelPipe(pipe)
+			else
+				ring.pos = ring.pos.next
+			end
+
+			-- Update bandwidth counters on successful sends.
+			local didSend = (sendResult == SendAddonMessageResult.Success)
+			if didSend then
+				Prio.avail = Prio.avail - msg.nSize
+				Prio.nTotalSent = Prio.nTotalSent + msg.nSize
+			end
+
+			-- Notify caller of message submission.
+			if msg.callbackFn then
+				securecallfunction(msg.callbackFn, msg.callbackArg, didSend, sendResult)
+			end
 		end
-		-- notify caller of delivery (even if we didn't send it)
-		if msg.callbackFn then
-			msg.callbackFn (msg.callbackArg, didSend)
-		end
-		-- USER CALLBACK MAY ERROR
 	end
 end
 
@@ -342,6 +445,7 @@ function ChatThrottleLib.OnUpdate(this,delay)
 	local self = ChatThrottleLib
 
 	self.OnUpdateDelay = self.OnUpdateDelay + delay
+	self.BlockedQueuesDelay = self.BlockedQueuesDelay + delay
 	if self.OnUpdateDelay < 0.08 then
 		return
 	end
@@ -353,40 +457,60 @@ function ChatThrottleLib.OnUpdate(this,delay)
 		return -- argh. some bastard is spewing stuff past the lib. just bail early to save cpu.
 	end
 
-	-- See how many of our priorities have queued messages (we only have 3, don't worry about the loop)
-	local n = 0
-	for prioname,Prio in pairs(self.Prio) do
-		if Prio.Ring.pos or Prio.avail < 0 then
-			n = n + 1
+	-- Integrate blocked queues back into their rings periodically.
+	if self.BlockedQueuesDelay >= 0.35 then
+		for _, Prio in pairs(self.Prio) do
+			Ring_Link(Prio.Ring, Prio.Blocked)
 		end
+
+		self.BlockedQueuesDelay = 0
 	end
 
-	-- Anything queued still?
-	if n<1 then
-		-- Nope. Move spillover bandwidth to global availability gauge and clear self.bQueueing
-		for prioname, Prio in pairs(self.Prio) do
+	-- See how many of our priorities have queued messages. This is split
+	-- into two counters because priorities that consist only of blocked
+	-- queues must keep our OnUpdate alive, but shouldn't count toward
+	-- bandwidth distribution.
+	local nSendablePrios = 0
+	local nBlockedPrios = 0
+
+	for prioname, Prio in pairs(self.Prio) do
+		if Prio.Ring.pos then
+			nSendablePrios = nSendablePrios + 1
+		elseif Prio.Blocked.pos then
+			nBlockedPrios = nBlockedPrios + 1
+		end
+
+		-- Collect unused bandwidth from priorities with nothing to send.
+		if not Prio.Ring.pos then
 			self.avail = self.avail + Prio.avail
 			Prio.avail = 0
 		end
-		self.bQueueing = false
-		self.Frame:Hide()
+	end
+
+	-- Bandwidth reclamation may take us back over the burst cap.
+	self.avail = math_min(self.avail, self.BURST)
+
+	-- If we can't currently send on any priorities, stop processing early.
+	if nSendablePrios == 0 then
+		-- If we're completely out of data to send, disable queue processing.
+		if nBlockedPrios == 0 then
+			self.bQueueing = false
+			self.Frame:Hide()
+		end
+
 		return
 	end
 
 	-- There's stuff queued. Hand out available bandwidth to priorities as needed and despool their queues
-	local avail = self.avail/n
+	local avail = self.avail / nSendablePrios
 	self.avail = 0
 
 	for prioname, Prio in pairs(self.Prio) do
-		if Prio.Ring.pos or Prio.avail < 0 then
+		if Prio.Ring.pos then
 			Prio.avail = Prio.avail + avail
-			if Prio.Ring.pos and Prio.avail > Prio.Ring.pos[1].nSize then
-				self:Despool(Prio)
-				-- Note: We might not get here if the user-supplied callback function errors out! Take care!
-			end
+			self:Despool(Prio)
 		end
 	end
-
 end
 
 
@@ -429,21 +553,27 @@ function ChatThrottleLib:SendChatMessage(prio, prefix,   text, chattype, languag
 
 	-- Check if there's room in the global available bandwidth gauge to send directly
 	if not self.bQueueing and nSize < self:UpdateAvail() then
-		self.avail = self.avail - nSize
-		bMyTraffic = true
-		_G.SendChatMessage(text, chattype, language, destination)
-		bMyTraffic = false
-		self.Prio[prio].nTotalSent = self.Prio[prio].nTotalSent + nSize
-		if callbackFn then
-			callbackFn (callbackArg, true)
+		local sendResult = PerformSend(_G.C_ChatInfo.SendChatMessage or _G.SendChatMessage, text, chattype, language, destination)
+
+		if not IsThrottledSendResult(sendResult) then
+			local didSend = (sendResult == SendAddonMessageResult.Success)
+
+			if didSend then
+				self.avail = self.avail - nSize
+				self.Prio[prio].nTotalSent = self.Prio[prio].nTotalSent + nSize
+			end
+
+			if callbackFn then
+				securecallfunction(callbackFn, callbackArg, didSend, sendResult)
+			end
+
+			return
 		end
-		-- USER CALLBACK MAY ERROR
-		return
 	end
 
 	-- Message needs to be queued
 	local msg = NewMsg()
-	msg.f = _G.SendChatMessage
+	msg.f = _G.C_ChatInfo.SendChatMessage or _G.SendChatMessage
 	msg[1] = text
 	msg[2] = chattype or "SAY"
 	msg[3] = language
@@ -453,54 +583,36 @@ function ChatThrottleLib:SendChatMessage(prio, prefix,   text, chattype, languag
 	msg.callbackFn = callbackFn
 	msg.callbackArg = callbackArg
 
-	self:Enqueue(prio, queueName or (prefix..(chattype or "SAY")..(destination or "")), msg)
+	self:Enqueue(prio, queueName or prefix, msg)
 end
 
 
-function ChatThrottleLib:SendAddonMessage(prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
-	if not self or not prio or not prefix or not text or not chattype or not self.Prio[prio] then
-		error('Usage: ChatThrottleLib:SendAddonMessage("{BULK||NORMAL||ALERT}", "prefix", "text", "chattype"[, "target"])', 2)
-	end
-	if callbackFn and type(callbackFn)~="function" then
-		error('ChatThrottleLib:SendAddonMessage(): callbackFn: expected function, got '..type(callbackFn), 2)
-	end
-
-	local nSize = text:len();
-
-	if C_ChatInfo or RegisterAddonMessagePrefix then
-		if nSize>255 then
-			error("ChatThrottleLib:SendAddonMessage(): message length cannot exceed 255 bytes", 2)
-		end
-	else
-		nSize = nSize + prefix:len() + 1
-		if nSize>255 then
-			error("ChatThrottleLib:SendAddonMessage(): prefix + message length cannot exceed 254 bytes", 2)
-		end
-	end
-
-	nSize = nSize + self.MSG_OVERHEAD;
+local function SendAddonMessageInternal(self, sendFunction, prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+	local nSize = #text + self.MSG_OVERHEAD
 
 	-- Check if there's room in the global available bandwidth gauge to send directly
 	if not self.bQueueing and nSize < self:UpdateAvail() then
-		self.avail = self.avail - nSize
-		bMyTraffic = true
-		if _G.C_ChatInfo then
-			_G.C_ChatInfo.SendAddonMessage(prefix, text, chattype, target)
-		else
-			_G.SendAddonMessage(prefix, text, chattype, target)
+		local sendResult = PerformSend(sendFunction, prefix, text, chattype, target)
+
+		if not IsThrottledSendResult(sendResult) then
+			local didSend = (sendResult == SendAddonMessageResult.Success)
+
+			if didSend then
+				self.avail = self.avail - nSize
+				self.Prio[prio].nTotalSent = self.Prio[prio].nTotalSent + nSize
+			end
+
+			if callbackFn then
+				securecallfunction(callbackFn, callbackArg, didSend, sendResult)
+			end
+
+			return
 		end
-		bMyTraffic = false
-		self.Prio[prio].nTotalSent = self.Prio[prio].nTotalSent + nSize
-		if callbackFn then
-			callbackFn (callbackArg, true)
-		end
-		-- USER CALLBACK MAY ERROR
-		return
 	end
 
 	-- Message needs to be queued
 	local msg = NewMsg()
-	msg.f = _G.C_ChatInfo and _G.C_ChatInfo.SendAddonMessage or _G.SendAddonMessage
+	msg.f = sendFunction
 	msg[1] = prefix
 	msg[2] = text
 	msg[3] = chattype
@@ -510,10 +622,65 @@ function ChatThrottleLib:SendAddonMessage(prio, prefix, text, chattype, target, 
 	msg.callbackFn = callbackFn
 	msg.callbackArg = callbackArg
 
-	self:Enqueue(prio, queueName or (prefix..chattype..(target or "")), msg)
+	self:Enqueue(prio, queueName or prefix, msg)
 end
 
 
+function ChatThrottleLib:SendAddonMessage(prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+	if not self or not prio or not prefix or not text or not chattype or not self.Prio[prio] then
+		error('Usage: ChatThrottleLib:SendAddonMessage("{BULK||NORMAL||ALERT}", "prefix", "text", "chattype"[, "target"])', 2)
+	elseif callbackFn and type(callbackFn)~="function" then
+		error('ChatThrottleLib:SendAddonMessage(): callbackFn: expected function, got '..type(callbackFn), 2)
+	elseif #text>255 then
+		error("ChatThrottleLib:SendAddonMessage(): message length cannot exceed 255 bytes", 2)
+	end
+
+	local sendFunction = _G.C_ChatInfo.SendAddonMessage
+	SendAddonMessageInternal(self, sendFunction, prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+end
+
+
+function ChatThrottleLib:SendAddonMessageLogged(prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+	if not self or not prio or not prefix or not text or not chattype or not self.Prio[prio] then
+		error('Usage: ChatThrottleLib:SendAddonMessageLogged("{BULK||NORMAL||ALERT}", "prefix", "text", "chattype"[, "target"])', 2)
+	elseif callbackFn and type(callbackFn)~="function" then
+		error('ChatThrottleLib:SendAddonMessageLogged(): callbackFn: expected function, got '..type(callbackFn), 2)
+	elseif #text>255 then
+		error("ChatThrottleLib:SendAddonMessageLogged(): message length cannot exceed 255 bytes", 2)
+	end
+
+	local sendFunction = _G.C_ChatInfo.SendAddonMessageLogged
+	SendAddonMessageInternal(self, sendFunction, prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+end
+
+local function BNSendGameDataReordered(prefix, text, _, gameAccountID)
+	local bnSendFunc = _G.C_BattleNet and _G.C_BattleNet.SendGameData or _G.BNSendGameData
+	return bnSendFunc(gameAccountID, prefix, text)
+end
+
+function ChatThrottleLib:BNSendGameData(prio, prefix, text, chattype, gameAccountID, queueName, callbackFn, callbackArg)
+	-- Note that this API is intentionally limited to 255 bytes of data
+	-- for reasons of traffic fairness, which is less than the 4078 bytes
+	-- BNSendGameData natively supports. Additionally, a chat type is required
+	-- but must always be set to 'WHISPER' to match what is exposed by the
+	-- receipt event.
+	--
+	-- If splitting messages, callers must also be aware that message
+	-- delivery over BNSendGameData is unordered.
+
+	if not self or not prio or not prefix or not text or not gameAccountID or not chattype or not self.Prio[prio] then
+		error('Usage: ChatThrottleLib:BNSendGameData("{BULK||NORMAL||ALERT}", "prefix", "text", "chattype", gameAccountID)', 2)
+	elseif callbackFn and type(callbackFn)~="function" then
+		error('ChatThrottleLib:BNSendGameData(): callbackFn: expected function, got '..type(callbackFn), 2)
+	elseif #text>255 then
+		error("ChatThrottleLib:BNSendGameData(): message length cannot exceed 255 bytes", 2)
+	elseif chattype ~= "WHISPER" then
+		error("ChatThrottleLib:BNSendGameData(): chat type must be 'WHISPER'", 2)
+	end
+
+	local sendFunction = BNSendGameDataReordered
+	SendAddonMessageInternal(self, sendFunction, prio, prefix, text, chattype, gameAccountID, queueName, callbackFn, callbackArg)
+end
 
 
 -----------------------------------------------------------------------

--- a/libs/Ace3/AceConfig-3.0/AceConfig-3.0.lua
+++ b/libs/Ace3/AceConfig-3.0/AceConfig-3.0.lua
@@ -3,7 +3,7 @@
 -- as well as associate it with a slash command.
 -- @class file
 -- @name AceConfig-3.0
--- @release $Id: AceConfig-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
+-- @release $Id: AceConfig-3.0.lua 1335 2024-05-05 19:35:16Z nevcairiel $
 
 --[[
 AceConfig-3.0
@@ -27,7 +27,7 @@ if not AceConfig then return end
 local pcall, error, type, pairs = pcall, error, type, pairs
 
 -- -------------------------------------------------------------------
--- :RegisterOptionsTable(appName, options, slashcmd, persist)
+-- :RegisterOptionsTable(appName, options, slashcmd)
 --
 -- - appName - (string) application name
 -- - options - table or function ref, see AceConfigRegistry

--- a/libs/Ace3/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
+++ b/libs/Ace3/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
@@ -1,13 +1,13 @@
 --- AceConfigDialog-3.0 generates AceGUI-3.0 based windows based on option tables.
 -- @class file
 -- @name AceConfigDialog-3.0
--- @release $Id: AceConfigDialog-3.0.lua 1296 2022-11-04 18:50:10Z nevcairiel $
+-- @release $Id: AceConfigDialog-3.0.lua 1372 2025-10-05 05:38:34Z nevcairiel $
 
 local LibStub = LibStub
 local gui = LibStub("AceGUI-3.0")
 local reg = LibStub("AceConfigRegistry-3.0")
 
-local MAJOR, MINOR = "AceConfigDialog-3.0", 86
+local MAJOR, MINOR = "AceConfigDialog-3.0", 89
 local AceConfigDialog, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 
 if not AceConfigDialog then return end
@@ -517,7 +517,7 @@ local function OptionOnMouseOver(widget, event)
 
 	if descStyle and descStyle ~= "tooltip" then return end
 
-	tooltip:SetText(name, 1, .82, 0, true)
+	tooltip:SetText(name, 1, .82, 0, 1, true)
 
 	if opt.type == "multiselect" then
 		tooltip:AddLine(user.text, 0.5, 0.5, 0.8, true)
@@ -526,7 +526,7 @@ local function OptionOnMouseOver(widget, event)
 		tooltip:AddLine(desc, 1, 1, 1, true)
 	end
 	if type(usage) == "string" then
-		tooltip:AddLine("Usage: "..usage, NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, true)
+		tooltip:AddLine(usage, NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, true)
 	end
 
 	tooltip:Show()
@@ -544,6 +544,7 @@ local function GetFuncName(option)
 	end
 end
 do
+	local InCombatLockdown = InCombatLockdown
 	local frame = AceConfigDialog.popup
 	if not frame or oldminor < 81 then
 		frame = CreateFrame("Frame", nil, UIParent)
@@ -556,13 +557,15 @@ do
 		frame:SetFrameLevel(100) -- Lots of room to draw under it
 		frame:SetScript("OnKeyDown", function(self, key)
 			if key == "ESCAPE" then
-				self:SetPropagateKeyboardInput(false)
+				if not InCombatLockdown() then
+					self:SetPropagateKeyboardInput(false)
+				end
 				if self.cancel:IsShown() then
 					self.cancel:Click()
 				else -- Showing a validation error
 					self:Hide()
 				end
-			else
+			elseif not InCombatLockdown() then
 				self:SetPropagateKeyboardInput(true)
 			end
 		end)
@@ -1503,7 +1506,7 @@ local function TreeOnButtonEnter(widget, event, uniquevalue, button)
 		tooltip:SetPoint("LEFT",button,"RIGHT")
 	end
 
-	tooltip:SetText(name, 1, .82, 0, true)
+	tooltip:SetText(name, 1, .82, 0, 1, true)
 
 	if type(desc) == "string" then
 		tooltip:AddLine(desc, 1, 1, 1, true)

--- a/libs/Ace3/AceDB-3.0/AceDB-3.0.lua
+++ b/libs/Ace3/AceDB-3.0/AceDB-3.0.lua
@@ -40,8 +40,8 @@
 -- end
 -- @class file
 -- @name AceDB-3.0.lua
--- @release $Id: AceDB-3.0.lua 1306 2023-06-23 14:55:09Z nevcairiel $
-local ACEDB_MAJOR, ACEDB_MINOR = "AceDB-3.0", 28
+-- @release $Id: AceDB-3.0.lua 1364 2025-07-05 16:01:08Z nevcairiel $
+local ACEDB_MAJOR, ACEDB_MINOR = "AceDB-3.0", 33
 local AceDB = LibStub:NewLibrary(ACEDB_MAJOR, ACEDB_MINOR)
 
 if not AceDB then return end -- No upgrade needed
@@ -360,7 +360,7 @@ local function logoutHandler(frame, event)
 
 			-- cleanup sections that are empty without defaults
 			local sv = rawget(db, "sv")
-			for section in pairs(db.keys) do
+			for section in pairs(rawget(db, "keys")) do
 				if rawget(sv, section) then
 					-- global is special, all other sections have sub-entrys
 					-- also don't delete empty profiles on main dbs, only on namespaces
@@ -373,6 +373,26 @@ local function logoutHandler(frame, event)
 					end
 					if not next(sv[section]) then
 						sv[section] = nil
+					end
+				end
+			end
+		end
+
+		-- second pass after everything else is cleaned up to remove empty namespaces
+		-- can't be run in-loop above since there is no guaranteed order
+		for db in pairs(AceDB.db_registry) do
+			local sv = rawget(db, "sv")
+			local namespaces = rawget(sv, "namespaces")
+			if namespaces then
+				for name in pairs(namespaces) do
+					-- cleanout empty profiles table, if still present
+					if namespaces[name].profiles and not next(namespaces[name].profiles) then
+						namespaces[name].profiles = nil
+					end
+
+					-- remove entire namespace, if needed
+					if not next(namespaces[name]) then
+						namespaces[name] = nil
 					end
 				end
 			end
@@ -525,6 +545,17 @@ function DBObjectLib:DeleteProfile(name, silent)
 		end
 	end
 
+	-- remove from unloaded namespaces
+	if self.sv.namespaces then
+		for nsname, data in pairs(self.sv.namespaces) do
+			if self.children and self.children[nsname] then
+				-- already a mapped namespace
+			elseif data.profiles then
+				data.profiles[name] = nil
+			end
+		end
+	end
+
 	-- switch all characters that use this profile back to the default
 	if self.sv.profileKeys then
 		for key, profile in pairs(self.sv.profileKeys) do
@@ -570,6 +601,20 @@ function DBObjectLib:CopyProfile(name, silent)
 		end
 	end
 
+	-- copy unloaded namespaces
+	if self.sv.namespaces then
+		for nsname, data in pairs(self.sv.namespaces) do
+			if self.children and self.children[nsname] then
+				-- already a mapped namespace
+			elseif data.profiles then
+				-- reset the current profile
+				data.profiles[self.keys.profile] = {}
+				-- copy data
+				copyTable(data.profiles[name], data.profiles[self.keys.profile])
+			end
+		end
+	end
+
 	-- Callback: OnProfileCopied, database, sourceProfileKey
 	self.callbacks:Fire("OnProfileCopied", self, name)
 end
@@ -596,6 +641,18 @@ function DBObjectLib:ResetProfile(noChildren, noCallbacks)
 		end
 	end
 
+	-- reset unloaded namespaces
+	if self.sv.namespaces and not noChildren then
+		for nsname, data in pairs(self.sv.namespaces) do
+			if self.children and self.children[nsname] then
+				-- already a mapped namespace
+			elseif data.profiles then
+				-- reset the current profile
+				data.profiles[self.keys.profile] = nil
+			end
+		end
+	end
+
 	-- Callback: OnProfileReset, database
 	if not noCallbacks then
 		self.callbacks:Fire("OnProfileReset", self)
@@ -606,8 +663,8 @@ end
 -- profile.
 -- @param defaultProfile The profile name to use as the default
 function DBObjectLib:ResetDB(defaultProfile)
-	if defaultProfile and type(defaultProfile) ~= "string" then
-		error(("Usage: AceDBObject:ResetDB(defaultProfile): 'defaultProfile' - string or nil expected, got %q."):format(type(defaultProfile)), 2)
+	if defaultProfile and type(defaultProfile) ~= "string" and defaultProfile ~= true then
+		error(("Usage: AceDBObject:ResetDB(defaultProfile): 'defaultProfile' - string or true expected, got %q."):format(type(defaultProfile)), 2)
 	end
 
 	local sv = self.sv

--- a/libs/Ace3/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
+++ b/libs/Ace3/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
@@ -2,7 +2,7 @@
 TreeGroup Container
 Container that uses a tree control to switch between groups.
 -------------------------------------------------------------------------------]]
-local Type, Version = "TreeGroup", 47
+local Type, Version = "TreeGroup", 48
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -387,10 +387,6 @@ local methods = {
 	["RefreshTree"] = function(self,scrollToSelection,fromOnUpdate)
 		local buttons = self.buttons
 		local lines = self.lines
-
-		for i, v in ipairs(buttons) do
-			v:Hide()
-		end
 		while lines[1] do
 			local t = tremove(lines)
 			for k in pairs(t) do
@@ -499,6 +495,10 @@ local methods = {
 			buttonnum = buttonnum + 1
 		end
 
+		-- We hide the remaining buttons after updating others to avoid a blizzard bug that keeps them interactable even if hidden when hidden before updating the buttons.
+		for i = buttonnum, #buttons do
+			buttons[i]:Hide()
+		end
 	end,
 
 	["SetSelected"] = function(self, value)

--- a/libs/Ace3/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
+++ b/libs/Ace3/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
@@ -1,7 +1,7 @@
 --[[-----------------------------------------------------------------------------
 ColorPicker Widget
 -------------------------------------------------------------------------------]]
-local Type, Version = "ColorPicker", 25
+local Type, Version = "ColorPicker", 28
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -11,12 +11,23 @@ local pairs = pairs
 -- WoW APIs
 local CreateFrame, UIParent = CreateFrame, UIParent
 
+-- Unfortunately we have no way to realistically detect if a client uses inverted alpha
+-- as no API will tell you. Wrath uses the old colorpicker, era uses the new one, both are inverted
+local INVERTED_ALPHA = (WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE)
+
 --[[-----------------------------------------------------------------------------
 Support functions
 -------------------------------------------------------------------------------]]
 local function ColorCallback(self, r, g, b, a, isAlpha)
+	if INVERTED_ALPHA and a then
+		a = 1 - a
+	end
 	if not self.HasAlpha then
 		a = 1
+	end
+	-- no change, skip update
+	if r == self.r and g == self.g and b == self.b and a == self.a then
+		return
 	end
 	self:SetColor(r, g, b, a)
 	if ColorPickerFrame:IsVisible() then
@@ -50,30 +61,63 @@ local function ColorSwatch_OnClick(frame)
 		ColorPickerFrame:SetFrameLevel(frame:GetFrameLevel() + 10)
 		ColorPickerFrame:SetClampedToScreen(true)
 
-		ColorPickerFrame.func = function()
-			local r, g, b = ColorPickerFrame:GetColorRGB()
-			local a = 1 - OpacitySliderFrame:GetValue()
-			ColorCallback(self, r, g, b, a)
-		end
+		if ColorPickerFrame.SetupColorPickerAndShow then -- 10.2.5 color picker overhaul
+			local r2, g2, b2, a2 = self.r, self.g, self.b, (self.a or 1)
+			if INVERTED_ALPHA then
+				a2 = 1 - a2
+			end
 
-		ColorPickerFrame.hasOpacity = self.HasAlpha
-		ColorPickerFrame.opacityFunc = function()
-			local r, g, b = ColorPickerFrame:GetColorRGB()
-			local a = 1 - OpacitySliderFrame:GetValue()
-			ColorCallback(self, r, g, b, a, true)
-		end
+			local info = {
+				swatchFunc = function()
+					local r, g, b = ColorPickerFrame:GetColorRGB()
+					local a = ColorPickerFrame:GetColorAlpha()
+					ColorCallback(self, r, g, b, a)
+				end,
 
-		local r, g, b, a = self.r, self.g, self.b, self.a
-		if self.HasAlpha then
-			ColorPickerFrame.opacity = 1 - (a or 0)
-		end
-		ColorPickerFrame:SetColorRGB(r, g, b)
+				hasOpacity = self.HasAlpha,
+				opacityFunc = function()
+					local r, g, b = ColorPickerFrame:GetColorRGB()
+					local a = ColorPickerFrame:GetColorAlpha()
+					ColorCallback(self, r, g, b, a, true)
+				end,
+				opacity = a2,
 
-		ColorPickerFrame.cancelFunc = function()
-			ColorCallback(self, r, g, b, a, true)
-		end
+				cancelFunc = function()
+					ColorCallback(self, r2, g2, b2, a2, true)
+				end,
 
-		ColorPickerFrame:Show()
+				r = r2,
+				g = g2,
+				b = b2,
+			}
+
+			ColorPickerFrame:SetupColorPickerAndShow(info)
+		else
+			ColorPickerFrame.func = function()
+				local r, g, b = ColorPickerFrame:GetColorRGB()
+				local a = OpacitySliderFrame:GetValue()
+				ColorCallback(self, r, g, b, a)
+			end
+
+			ColorPickerFrame.hasOpacity = self.HasAlpha
+			ColorPickerFrame.opacityFunc = function()
+				local r, g, b = ColorPickerFrame:GetColorRGB()
+				local a = OpacitySliderFrame:GetValue()
+				ColorCallback(self, r, g, b, a, true)
+			end
+
+			local r, g, b, a = self.r, self.g, self.b, 1 - (self.a or 1)
+			if self.HasAlpha then
+				ColorPickerFrame.opacity = a
+			end
+			ColorPickerFrame:SetColorRGB(r, g, b)
+
+			ColorPickerFrame.cancelFunc = function()
+				ColorCallback(self, r, g, b, a, true)
+			end
+
+			ColorPickerFrame:Show()
+		end
 	end
 	AceGUI:ClearFocus()
 end

--- a/libs/Ace3/AceGUI-3.0/widgets/AceGUIWidget-EditBox.lua
+++ b/libs/Ace3/AceGUI-3.0/widgets/AceGUIWidget-EditBox.lua
@@ -1,7 +1,7 @@
 --[[-----------------------------------------------------------------------------
 EditBox Widget
 -------------------------------------------------------------------------------]]
-local Type, Version = "EditBox", 28
+local Type, Version = "EditBox", 29
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -10,7 +10,7 @@ local tostring, pairs = tostring, pairs
 
 -- WoW APIs
 local PlaySound = PlaySound
-local GetCursorInfo, ClearCursor, GetSpellInfo = GetCursorInfo, ClearCursor, GetSpellInfo
+local GetCursorInfo, ClearCursor = GetCursorInfo, ClearCursor
 local CreateFrame, UIParent = CreateFrame, UIParent
 local _G = _G
 
@@ -19,7 +19,11 @@ Support functions
 -------------------------------------------------------------------------------]]
 if not AceGUIEditBoxInsertLink then
 	-- upgradeable hook
-	hooksecurefunc("ChatEdit_InsertLink", function(...) return _G.AceGUIEditBoxInsertLink(...) end)
+	if ChatFrameUtil and ChatFrameUtil.InsertLink then
+		hooksecurefunc(ChatFrameUtil, "InsertLink", function(...) return _G.AceGUIEditBoxInsertLink(...) end)
+	elseif ChatEdit_InsertLink then
+		hooksecurefunc("ChatEdit_InsertLink", function(...) return _G.AceGUIEditBoxInsertLink(...) end)
+	end
 end
 
 function _G.AceGUIEditBoxInsertLink(text)
@@ -76,12 +80,16 @@ end
 
 local function EditBox_OnReceiveDrag(frame)
 	local self = frame.obj
-	local type, id, info = GetCursorInfo()
+	local type, id, info, extra = GetCursorInfo()
 	local name
 	if type == "item" then
 		name = info
 	elseif type == "spell" then
-		name = GetSpellInfo(id, info)
+		if C_Spell and C_Spell.GetSpellName then
+			name = C_Spell.GetSpellName(extra)
+		else
+			name = GetSpellInfo(id, info)
+		end
 	elseif type == "macro" then
 		name = GetMacroInfo(id)
 	end

--- a/libs/Ace3/AceGUI-3.0/widgets/AceGUIWidget-MultiLineEditBox.lua
+++ b/libs/Ace3/AceGUI-3.0/widgets/AceGUIWidget-MultiLineEditBox.lua
@@ -1,4 +1,4 @@
-local Type, Version = "MultiLineEditBox", 32
+local Type, Version = "MultiLineEditBox", 33
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -6,7 +6,7 @@ if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 local pairs = pairs
 
 -- WoW APIs
-local GetCursorInfo, GetSpellInfo, ClearCursor = GetCursorInfo, GetSpellInfo, ClearCursor
+local GetCursorInfo, ClearCursor = GetCursorInfo, ClearCursor
 local CreateFrame, UIParent = CreateFrame, UIParent
 local _G = _G
 
@@ -16,7 +16,11 @@ Support functions
 
 if not AceGUIMultiLineEditBoxInsertLink then
 	-- upgradeable hook
-	hooksecurefunc("ChatEdit_InsertLink", function(...) return _G.AceGUIMultiLineEditBoxInsertLink(...) end)
+	if ChatFrameUtil and ChatFrameUtil.InsertLink then
+		hooksecurefunc(ChatFrameUtil, "InsertLink", function(...) return _G.AceGUIMultiLineEditBoxInsertLink(...) end)
+	elseif ChatEdit_InsertLink then
+		hooksecurefunc("ChatEdit_InsertLink", function(...) return _G.AceGUIMultiLineEditBoxInsertLink(...) end)
+	end
 end
 
 function _G.AceGUIMultiLineEditBoxInsertLink(text)
@@ -100,9 +104,13 @@ local function OnMouseUp(self)                                                  
 end
 
 local function OnReceiveDrag(self)                                               -- EditBox / ScrollFrame
-	local type, id, info = GetCursorInfo()
+	local type, id, info, extra = GetCursorInfo()
 	if type == "spell" then
-		info = GetSpellInfo(id, info)
+		if C_Spell and C_Spell.GetSpellName then
+			info = C_Spell.GetSpellName(extra)
+		else
+			info = GetSpellInfo(id, info)
+		end
 	elseif type ~= "item" then
 		return
 	end

--- a/libs/Ace3/AceTimer-3.0/AceTimer-3.0.lua
+++ b/libs/Ace3/AceTimer-3.0/AceTimer-3.0.lua
@@ -15,7 +15,7 @@
 -- make into AceTimer.
 -- @class file
 -- @name AceTimer-3.0
--- @release $Id: AceTimer-3.0.lua 1284 2022-09-25 09:15:30Z nevcairiel $
+-- @release $Id: AceTimer-3.0.lua 1342 2024-05-26 11:49:35Z nevcairiel $
 
 local MAJOR, MINOR = "AceTimer-3.0", 17 -- Bump minor on changes
 local AceTimer, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
@@ -78,7 +78,7 @@ end
 
 --- Schedule a new one-shot timer.
 -- The timer will fire once in `delay` seconds, unless canceled before.
--- @param callback Callback function for the timer pulse (funcref or method name).
+-- @param func Callback function for the timer pulse (funcref or method name).
 -- @param delay Delay for the timer, in seconds.
 -- @param ... An optional, unlimited amount of arguments to pass to the callback function.
 -- @usage
@@ -107,7 +107,7 @@ end
 
 --- Schedule a repeating timer.
 -- The timer will fire every `delay` seconds, until canceled.
--- @param callback Callback function for the timer pulse (funcref or method name).
+-- @param func Callback function for the timer pulse (funcref or method name).
 -- @param delay Delay for the timer, in seconds.
 -- @param ... An optional, unlimited amount of arguments to pass to the callback function.
 -- @usage


### PR DESCRIPTION
To Do: Update Ace3 with Midnight Compatible version

Current changes:
1. Wait for addon to load before handling saved variables.
2. Add a new saved variable and set it to true after the first log in on 12.0.0
3. Perform a one-time disable if build version is 12.0.0 and BeQuiet is Enabled (so that users don't miss launch content). A message indicating as such as been added.
4. Moved the msg_user function to the top of the file so that it can be access by the saved variable code
5. Update Ace3 to release 1377

Testing:
1. Disabling of talking heads seems functional and error-free on beta
2. Slash commands and saved variable handling seems functional
3. Validated talking heads are blocked in combat and in dungeons in combat on beta
4. No more errors in the UI options with latest Ace3 release on beta