### PR TITLE
new features:  keybindings to close the talking head

### DIFF
--- a/BeQuiet.lua
+++ b/BeQuiet.lua
@@ -76,18 +76,11 @@ var_frame:SetScript("OnEvent", function(self, event, arg1)
 			BQ_ENABLE_ESCAPE = false
 		end
 
-		init(self)
+		_G["BINDING_NAME_BeQuiet_CloseTalkingHead"] = ADDON_NAME .. " - Close Talking Head" -- see Bindings.xml
+
+		BQ.versionLabel = "v" .. (C_AddOns.GetAddOnMetadata(ADDON_NAME, "Version") or "1")
 	end
 end)
-
-function init(self)
-	_G["BINDING_NAME_BeQuiet_CloseTalkingHead"] = ADDON_NAME .. " - Close Talking Head" -- see Bindings.xml
-
-	BQ.versionLabel = "v" .. (C_AddOns.GetAddOnMetadata(ADDON_NAME, "Version") or "1")
-	if VERBOSE then
-		msg_user("loaded " .. BQ.versionLabel)
-	end
-end
 
 -------------------------------------------------------------------------------
 -- Keybinding to let the use manually close the talking head
@@ -390,6 +383,25 @@ function MyAddonCommands(args)
 		end
 	end
 
+	-- ESCAPE KEY --
+
+	local escOriginal = BQ_ENABLE_ESCAPE
+
+	if args == 'esc' then
+		msg_user ('esc (on | off | toggle) - allow the escape key to close the talking head or not')
+	elseif args == 'esc on' then
+		BQ_ENABLE_ESCAPE = true
+	elseif args == 'esc off' then
+		BQ_ENABLE_ESCAPE = false
+	elseif args == 'esc toggle' then
+		BQ_ENABLE_ESCAPE = not BQ_ENABLE_ESCAPE
+	end
+
+	if escOriginal ~= BQ_ENABLE_ESCAPE then
+		local msgOnOrOff = BQ_ENABLE_ESCAPE and "enabled to close" or "disabled from closing"
+		msg_user('Escape key is now ' ..msgOnOrOff.. ' the talking head frame')
+	end
+
 	if args == 'whitelist' then
 		msg_user('whitelist (currentzone | currentsubzone) - toggle whitelisting for the current major zone (Orgrimmar) or sub-zone (Valley of Strength).')
 	end
@@ -404,7 +416,7 @@ function MyAddonCommands(args)
 
 	if args == '' then
 		msg_user('version ' .. BQ.versionLabel)
-		msg_user('Options: config | on | off | toggle | verbose | whitelist | blacklist | reset | delete | show | vo')
+		msg_user('Options: config | on | off | toggle | verbose | whitelist | blacklist | reset | delete | show | vo | esc')
 		msg_user('-----')
 		if ENABLED == 1 then
 			msg_user('is currently enabled.')

--- a/BeQuiet.lua
+++ b/BeQuiet.lua
@@ -72,6 +72,10 @@ var_frame:SetScript("OnEvent", function(self, event, arg1)
 			BLACKLIST = BL_DEFAULT
 		end
 
+		if BQ_ENABLE_ESCAPE == nil then
+			BQ_ENABLE_ESCAPE = false
+		end
+
 		init(self)
 	end
 end)
@@ -79,8 +83,9 @@ end)
 function init(self)
 	_G["BINDING_NAME_BeQuiet_CloseTalkingHead"] = ADDON_NAME .. " - Close Talking Head" -- see Bindings.xml
 
+	BQ.versionLabel = "v" .. (C_AddOns.GetAddOnMetadata(ADDON_NAME, "Version") or "1")
 	if VERBOSE then
-		msg_user("loaded " .. "v" .. (C_AddOns.GetAddOnMetadata(ADDON_NAME, "Version") or "1"))
+		msg_user("loaded " .. BQ.versionLabel)
 	end
 end
 
@@ -92,6 +97,8 @@ local keyNameToBind  = "Escape" -- will be temporarily stolen then restored to a
 local isBound
 
 function add_tmp_keybind_that_closes()
+	if not BQ_ENABLE_ESCAPE then return end
+
 	if not isBound then
 		SetOverrideBinding(TalkingHeadFrame, true, keyNameToBind, "BeQuiet_CloseTalkingHead") -- see Bindings.xml
 		isBound = true
@@ -394,7 +401,7 @@ function MyAddonCommands(args)
 	end
 
 	if args == '' then
-		msg_user('version ' .. version)
+		msg_user('version ' .. BQ.versionLabel)
 		msg_user('Options: config | on | off | toggle | verbose | whitelist | blacklist | reset | delete | show | vo')
 		msg_user('-----')
 		if ENABLED == 1 then

--- a/BeQuiet.lua
+++ b/BeQuiet.lua
@@ -100,6 +100,7 @@ function add_tmp_keybind_that_closes()
 	if not BQ_ENABLE_ESCAPE then return end
 
 	if not isBound then
+		if InCombatLockdown() then return end
 		SetOverrideBinding(TalkingHeadFrame, true, keyNameToBind, "BeQuiet_CloseTalkingHead") -- see Bindings.xml
 		isBound = true
 	end
@@ -111,6 +112,7 @@ function remove_tmp_keybind_that_closes()
 	--local stack = debugstack(1,3,0)
 	--DevTools_Dump(stack)
 
+	if InCombatLockdown() then return end
 	SetOverrideBinding(TalkingHeadFrame, true, keyNameToBind, nil)
 	isBound = false
 end

--- a/BeQuiet.toc
+++ b/BeQuiet.toc
@@ -3,7 +3,7 @@
 ## Title: BeQuiet
 ## Author: Xorag
 ## Notes: Suppresses talking chat head frame and audio
-## SavedVariables: ENABLED, VERBOSE, WHITELIST, BLACKLIST, VO_ENABLED, BQ_SHOW_HEADS, BQ_SUPPRESS_INSTANCES
+## SavedVariables: ENABLED, VERBOSE, WHITELIST, BLACKLIST, VO_ENABLED, BQ_SHOW_HEADS, BQ_SUPPRESS_INSTANCES, BQ_ENABLE_ESCAPE
 ## AddonCompartmentFunc: BeQuiet_BlizCompartment_OnClick
 ## IconTexture: 135975
 

--- a/Bindings.xml
+++ b/Bindings.xml
@@ -1,0 +1,5 @@
+<Bindings>
+	<Binding name="BeQuiet_CloseTalkingHead" header="TalkingHeadFrame" category="ADDONS" default="SHIFT-O">
+		GLOBAL_BeQuiet_CloseTalkingHead()
+	</Binding>
+</Bindings>

--- a/Options.lua
+++ b/Options.lua
@@ -76,7 +76,7 @@ function Options:init()
                     return hide
                 end,
                 type = 'description',
-                name = BQ_RED.."DISABLED! |r With neither Mute nor Hide, BeQuiet will effectively do nothing.",
+                name = BQ.RED.."DISABLED! |r With neither Mute nor Hide, BeQuiet will effectively do nothing.",
             },
 
             -------------------------------------------------------------------------------

--- a/Options.lua
+++ b/Options.lua
@@ -68,15 +68,29 @@ function Options:init()
                     return not is_true(BQ_SHOW_HEADS)
                 end,
             },
+            enableEscape = {
+                order = 65,
+                name = "Escape",
+                desc = "Enable the escape key to both close and silence the talking head",
+                type = "toggle",
+                set = function(optionsMenu, enableEscape)
+                    local msg = enableEscape and "Talking heads can now be shut down via the escape key." or "Escape key will have no effect on talking heads."
+                    msg_user(msg)
+                    BQ_ENABLE_ESCAPE = enableEscape
+                end,
+                get = function()
+                    return BQ_ENABLE_ESCAPE or false
+                end,
+            },
             warn_if_broke = {
                 order = 70,
                 hidden = function()
-                    local warn = is_true(VO_ENABLED) and is_true(BQ_SHOW_HEADS)
+                    local warn = is_true(VO_ENABLED) and is_true(BQ_SHOW_HEADS) and not BQ_ENABLE_ESCAPE
                     local hide = not warn
                     return hide
                 end,
                 type = 'description',
-                name = BQ.RED.."DISABLED! |r With neither Mute nor Hide, BeQuiet will effectively do nothing.",
+                name = BQ.RED.."DISABLED! |r With neither Mute, nor Hide, nor Escape, BeQuiet will effectively do nothing.",
             },
 
             -------------------------------------------------------------------------------


### PR DESCRIPTION
this update provides 2 new ways to Be Quiet and close/silence the talking head after it has appears / begun talking:
* configure a dedicated keybind in Blizzard's keybinding panels 
* the option to enable the Escape key to do the same without needing to dedicated a permanent keybinding

The escape option is defaulted to disabled as you requested.

I hope you like it.  Let me know what you think / need.